### PR TITLE
Use QStandardPaths::locate to search for emojis.json

### DIFF
--- a/src/core/Config.h
+++ b/src/core/Config.h
@@ -8,8 +8,7 @@ struct Config {
     constexpr static const auto ConfigFileName = "emojirunnerrc";
     constexpr static const auto RelativeConfigFolder = "/.config/krunnerplugins/";
     const static QString ConfigFilePath;
-    const static QString GlobalEmojiFilePath;
-    const static QString LocalEmojiFilePath;
+    const static QString SharedEmojiFileName;
     const static QString CustomEmojiFilePath;
     constexpr static const auto RootGroup = "Config";
     constexpr static const auto GlobalSearch = "globalSearch";
@@ -46,7 +45,6 @@ struct JSONEmoji {
 
 const QString Config::ConfigFilePath = QDir::homePath() + Config::RelativeConfigFolder + Config::ConfigFileName;
 const QString Config::CustomEmojiFilePath = QDir::homePath() + "/.local/share/emojirunner/customemojis.json";
-const QString Config::LocalEmojiFilePath = QDir::homePath() + "/.local/share/emojirunner/emojis.json";
-const QString Config::GlobalEmojiFilePath = QStringLiteral("/usr/share/emojirunner/emojis.json");
+const QString Config::SharedEmojiFileName = "emojirunner/emojis.json";
 }
 #endif // EMOJIRUNNER_CONFIG_H

--- a/src/core/FileReader.cpp
+++ b/src/core/FileReader.cpp
@@ -20,13 +20,11 @@ FileReader::FileReader(const KConfigGroup &config)
 QList<EmojiCategory> FileReader::getEmojiCategories(bool getAllEmojis) const
 {
     // Emojis for user level install
-    QFile globalFile(Config::GlobalEmojiFilePath);
-    QFile localFile(Config::LocalEmojiFilePath);
+    QString emojisFilePath = QStandardPaths::locate(QStandardPaths::GenericDataLocation, Config::SharedEmojiFileName, QStandardPaths::LocateFile);
+    QFile emojisFile(emojisFilePath);
     QMap<QString, EmojiCategory> preconfiguredEmojis;
-    if (globalFile.exists() && globalFile.open(QIODevice::ReadOnly)) {
-        preconfiguredEmojis = parseEmojiFile(getAllEmojis, globalFile);
-    } else if (localFile.exists() && localFile.open(QIODevice::ReadOnly)) {
-        preconfiguredEmojis = parseEmojiFile(getAllEmojis, localFile);
+    if (emojisFile.exists() && emojisFile.open(QIODevice::ReadOnly)) {
+        preconfiguredEmojis = parseEmojiFile(getAllEmojis, emojisFile);
     }
 
     // Read custom emojis


### PR DESCRIPTION
Solve #11

[QStandardPaths::GenericDataLocation](https://doc.qt.io/qt-5/qstandardpaths.html#locate:~:text=%22~/.cache/%3CAPPNAME%3E%22-,GenericDataLocation,%22~/.local/share%22%2C%20%22/usr/local/share%22%2C%20%22/usr/share%22,-RuntimeLocation)

I tested by moving emojis.json to `/usr/share/emojirunner` and `~/.local/share/emojirunner` manually, and it still works.

I have more changes to improve Emoji Runner in general, do you prefer one or individual pull requests ?