### PR TITLE
Use kquitapp6 for Plasma 6

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,11 @@ sudo make install/fast
 # KRunner needs to be restarted for the changes to be applied
 if pgrep -x krunner > /dev/null
 then
-    kquitapp5 krunner
+    if [[ "$krunner_version" == "6" ]]; then
+        kquitapp6 krunner
+    else
+        kquitapp5 krunner
+    fi
 fi
 
 echo "Installation finished!";

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -3,3 +3,15 @@
 set -e
 cd build
 sudo make uninstall
+
+# KRunner needs to be restarted for the changes to be applied
+krunner_version=$(krunner --version | grep -oP "(?<=krunner )\d+")
+if pgrep -x krunner > /dev/null
+then
+    if [[ "$krunner_version" == "6" ]]; then
+        kquitapp6 krunner
+    else
+        kquitapp5 krunner
+    fi
+fi
+


### PR DESCRIPTION
When installing from KDE store, restarting Krunner failed due to missing binary (for Plasma 6).
